### PR TITLE
The ideas page link is stale

### DIFF
--- a/faq/technical-faq/ethernet-connectivity.md
+++ b/faq/technical-faq/ethernet-connectivity.md
@@ -21,5 +21,7 @@ These resulting limitations were gathered using the following test setup.
 
 We've received feedback to create an ethernet-based logic analyzer. We are considering this for future generations of the hardware, so feel free to vote/comment your requirements on our ideas page [here!](https://ideas.saleae.com/ideas/SALEAE-I-174#1)
 
+TODO: Update the ideas.saleae.com link
+
 
 


### PR DESCRIPTION
The link at the bottom of the page "https://ideas.saleae.com/ideas/SALEAE-I-174#1" doesn't seem to go to a valid page.

I'm not sure how to locate the current location of this page, so I don't have a suggestion for a new link.